### PR TITLE
[Fix] Fix hardcoded Azure OpenAI API version in translator

### DIFF
--- a/pdf2zh/config/translate_engine_model.py
+++ b/pdf2zh/config/translate_engine_model.py
@@ -172,6 +172,9 @@ class AzureOpenAISettings(BaseModel):
     azure_openai_api_key: str | None = Field(
         default=None, description="API key for AzureOpenAI service"
     )
+    azure_openai_api_version: str = Field(
+        default="2024-06-01", description="API version for AzureOpenAI service"
+    )
 
     def validate_settings(self) -> None:
         if not self.azure_openai_api_key:

--- a/pdf2zh/translator/translator_impl/azueopenai.py
+++ b/pdf2zh/translator/translator_impl/azueopenai.py
@@ -26,7 +26,7 @@ class AzureOpenAITranslator(BaseTranslator):
         self.client = openai.AzureOpenAI(
             azure_endpoint=settings.translate_engine_settings.azure_openai_base_url,
             azure_deployment=settings.translate_engine_settings.azure_openai_model,
-            api_version="2024-06-01",
+            api_version=settings.translate_engine_settings.azure_openai_api_version,
             api_key=settings.translate_engine_settings.azure_openai_api_key,
         )
         self.add_cache_impact_parameters("temperature", self.options["temperature"])


### PR DESCRIPTION
I encountered an authentication error while testing my Azure OpenAI API key.  
After debugging, I found that the `api_version` was hardcoded instead of using the configured environment variable.  
This caused 401 errors like the following:

```
[04/27/25 15:50:37] ERROR ERROR:pdf2zh.converter:Error code: 401 - {'error': {'code': '401', 'message': 'Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.'}}
```

This PR fixes it by properly using the `AZURE_OPENAI_API_VERSION` from the environment settings.
